### PR TITLE
feat: build Evolvo homepage content

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
+import { getAllPosts } from "../lib/posts";
+
 import HomePage from "./page";
 
 vi.mock("next/link", () => ({
@@ -17,11 +19,16 @@ vi.mock("next/link", () => ({
 }));
 
 describe("HomePage", () => {
-  it("renders the visual-system hero and route links", () => {
+  it("renders the homepage narrative and blog preview links", () => {
+    const [firstPost] = getAllPosts();
     const markup = renderToStaticMarkup(<HomePage />);
 
-    expect(markup).toContain("Proof before polish.");
+    expect(markup).toContain(
+      "Evolvo improves itself through reviewable work, not marketing language.",
+    );
+    expect(markup).toContain("Operating model");
     expect(markup).toContain("href=\"/blog\"");
-    expect(markup).toContain("Graphite, off-white, ember");
+    expect(markup).toContain(firstPost.title);
+    expect(markup).toContain("Open the repository");
   });
 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,43 +1,74 @@
 import Link from "next/link";
 
 import PageSection from "../components/site/PageSection";
+import { formatPublishedAt, getAllPosts } from "../lib/posts";
 
-const systemCards = [
+const operatingModel = [
   {
-    label: "Palette",
-    value: "Graphite, off-white, ember",
-    detail: "Dark structural surfaces with a single warm accent for emphasis.",
+    label: "Inspect",
+    title: "Start from current state, not assumptions.",
+    detail:
+      "Evolvo reads the repository, checks the active branch, and narrows the task before it edits anything.",
   },
   {
-    label: "Typography",
-    value: "Display sans + technical mono",
-    detail: "A geometric headline voice backed by utilitarian metadata labels.",
+    label: "Implement",
+    title: "Ship one bounded change at a time.",
+    detail:
+      "Each patch stays small enough to review and focused enough to explain without hand-waving.",
   },
   {
-    label: "Layout",
-    value: "Dense grids, measured spacing",
-    detail: "Editorial rhythm over splash-page polish.",
+    label: "Validate",
+    title: "Let the repository disagree.",
+    detail:
+      "Lint, tests, builds, and startup checks are evidence, not ceremony. Green checks are required but never sufficient on their own.",
+  },
+  {
+    label: "Review",
+    title: "Keep only work that survives scrutiny.",
+    detail:
+      "Evolvo reviews the exact diff, looks for narrower alternatives, and rejects patches that are noisy, risky, or off-task.",
+  },
+] as const;
+
+const principles = [
+  {
+    label: "Bounded scope",
+    detail:
+      "The system defaults to the best next patch, not the biggest one. Small diffs reduce hidden regressions and make rollback simple.",
+  },
+  {
+    label: "Evidence over claims",
+    detail:
+      "Narrative is cheap. Logs, validation output, route behavior, and exact file changes are the actual proof that work is sound.",
+  },
+  {
+    label: "Acceptance is earned",
+    detail:
+      "A change is not good because it exists. It is good when it solves the issue, stays coherent with the code around it, and survives review.",
   },
 ] as const;
 
 export default function HomePage() {
+  const recentPosts = getAllPosts().slice(0, 3);
+
   return (
     <div className="space-y-6">
       <section className="rounded-[2.5rem] border border-stone-800/80 bg-stone-950/80 p-6 shadow-[0_18px_60px_rgba(0,0,0,0.32)] backdrop-blur sm:p-8 lg:p-10">
         <div className="grid gap-8 lg:grid-cols-[minmax(0,2.2fr)_minmax(0,1fr)] lg:items-end">
           <div className="space-y-6">
             <p className="font-mono text-[0.72rem] font-medium uppercase tracking-[0.32em] text-amber-400">
-              Issue #5 visual system
+              GitHub-native software worker
             </p>
             <div className="space-y-4">
               <h1 className="max-w-4xl text-4xl font-semibold tracking-[-0.05em] text-stone-50 sm:text-5xl lg:text-6xl">
-                Proof before polish.
+                Evolvo improves itself through reviewable work, not marketing language.
               </h1>
               <p className="max-w-2xl text-base leading-8 text-stone-300 sm:text-lg">
-                Evolvo&rsquo;s shell now speaks in the same voice as its review
-                loop: restrained, technical, and deliberate. The visual system
-                stays structured so later content can add depth without needing
-                to rebuild the frame around it.
+                Evolvo is a disciplined coding agent that inspects its own
+                repository, selects one bounded issue, implements the smallest
+                credible fix, validates the result, and keeps only changes that
+                survive scrutiny. The point is not to sound autonomous. The
+                point is to leave behind accepted diffs.
               </p>
             </div>
             <div className="flex flex-col gap-3 sm:flex-row">
@@ -45,7 +76,7 @@ export default function HomePage() {
                 href="/blog"
                 className="inline-flex items-center justify-center rounded-full border border-amber-400 bg-amber-400 px-5 py-3 font-mono text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-stone-950 transition-colors hover:bg-amber-300"
               >
-                Inspect the blog shell
+                Read the latest writing
               </Link>
               <a
                 href="https://github.com/evolvo-auto/evolvo-web"
@@ -60,83 +91,181 @@ export default function HomePage() {
           <div className="rounded-[2rem] border border-stone-800/80 bg-stone-900/70 p-5">
             <div className="flex items-center justify-between gap-4 border-b border-stone-800/80 pb-4">
               <p className="font-mono text-[0.68rem] uppercase tracking-[0.28em] text-stone-400">
-                Visual system
+                Credibility model
               </p>
               <span className="font-mono text-[0.68rem] uppercase tracking-[0.28em] text-amber-300">
-                stable
+                active
               </span>
             </div>
             <dl className="mt-4 space-y-4">
-              {systemCards.map((card) => (
-                <div
-                  key={card.label}
-                  className="rounded-2xl border border-stone-800/80 bg-stone-950/70 p-4"
-                >
-                  <dt className="font-mono text-[0.68rem] uppercase tracking-[0.28em] text-stone-400">
-                    {card.label}
-                  </dt>
-                  <dd className="mt-2 text-sm font-semibold text-stone-100">
-                    {card.value}
-                  </dd>
-                  <p className="mt-2 text-sm leading-7 text-stone-300">
-                    {card.detail}
-                  </p>
-                </div>
-              ))}
+              <div className="rounded-2xl border border-stone-800/80 bg-stone-950/70 p-4">
+                <dt className="font-mono text-[0.68rem] uppercase tracking-[0.28em] text-stone-400">
+                  Input
+                </dt>
+                <dd className="mt-2 text-sm font-semibold text-stone-100">
+                  Issue-backed tasks
+                </dd>
+                <p className="mt-2 text-sm leading-7 text-stone-300">
+                  Evolvo works from concrete repository issues instead of vague
+                  aspirations.
+                </p>
+              </div>
+              <div className="rounded-2xl border border-stone-800/80 bg-stone-950/70 p-4">
+                <dt className="font-mono text-[0.68rem] uppercase tracking-[0.28em] text-stone-400">
+                  Unit
+                </dt>
+                <dd className="mt-2 text-sm font-semibold text-stone-100">
+                  Small, reviewable diffs
+                </dd>
+                <p className="mt-2 text-sm leading-7 text-stone-300">
+                  Progress is measured in coherent patches that can be defended
+                  line by line.
+                </p>
+              </div>
+              <div className="rounded-2xl border border-stone-800/80 bg-stone-950/70 p-4">
+                <dt className="font-mono text-[0.68rem] uppercase tracking-[0.28em] text-stone-400">
+                  Trust
+                </dt>
+                <dd className="mt-2 text-sm font-semibold text-stone-100">
+                  Validation plus skeptical review
+                </dd>
+                <p className="mt-2 text-sm leading-7 text-stone-300">
+                  Passing checks matter, but only alongside a diff review that
+                  tries to reject weak work.
+                </p>
+              </div>
             </dl>
           </div>
         </div>
       </section>
       <PageSection
-        eyebrow="Shared patterns"
-        title="Reusable sections now carry the site tone."
-        description="The homepage and blog now sit inside the same container language: rounded graphite panels, mono metadata, and deliberate hierarchy for headings and support text."
+        eyebrow="Operating model"
+        title="This system earns trust by showing the work."
+        description="Evolvo’s loop is intentionally strict. It begins with inspection, routes through bounded implementation and repository validation, and ends with an explicit accept-or-reject decision."
       >
         <div className="grid gap-4 md:grid-cols-2">
-          <div className="rounded-[1.75rem] border border-stone-800/80 bg-stone-900/60 p-5">
-            <p className="font-mono text-[0.68rem] uppercase tracking-[0.28em] text-stone-400">
-              Shared shell
-            </p>
-            <p className="mt-3 text-base leading-7 text-stone-200">
-              Header, footer, and navigation now read as one system instead of
-              a temporary scaffold.
-            </p>
-          </div>
-          <div className="rounded-[1.75rem] border border-stone-800/80 bg-stone-900/60 p-5">
-            <p className="font-mono text-[0.68rem] uppercase tracking-[0.28em] text-stone-400">
-              Route composition
-            </p>
-            <p className="mt-3 text-base leading-7 text-stone-200">
-              Home and blog pages reuse the same section frame so later content
-              work can focus on substance instead of rebuilding layout.
-            </p>
-          </div>
+          {operatingModel.map((step) => (
+            <div
+              key={step.label}
+              className="rounded-[1.75rem] border border-stone-800/80 bg-stone-900/60 p-5"
+            >
+              <p className="font-mono text-[0.68rem] uppercase tracking-[0.28em] text-amber-300">
+                {step.label}
+              </p>
+              <h3 className="mt-3 text-xl font-semibold tracking-[-0.04em] text-stone-50">
+                {step.title}
+              </h3>
+              <p className="mt-3 text-sm leading-7 text-stone-300">
+                {step.detail}
+              </p>
+            </div>
+          ))}
         </div>
       </PageSection>
       <PageSection
-        eyebrow="Next issue fit"
-        title="The frame is ready for real content."
-        description="Issue #3 can now focus on homepage substance, and Issue #4 can build the markdown blog architecture inside a visual system that already exists."
+        eyebrow="Working principles"
+        title="The posture stays practical, skeptical, and narrow."
+        description="Evolvo avoids grand rewrites and vague autonomy claims. The homepage should make that operational stance explicit instead of asking visitors to infer it."
       >
-        <div className="grid gap-4 sm:grid-cols-2">
-          <div className="rounded-[1.75rem] border border-stone-800/80 bg-stone-950/80 p-5">
-            <p className="font-mono text-[0.68rem] uppercase tracking-[0.28em] text-amber-300">
-              Home
-            </p>
-            <p className="mt-3 text-sm leading-7 text-stone-300">
-              Ready for the operating model, principles, and showcase sections.
-            </p>
-          </div>
-          <div className="rounded-[1.75rem] border border-stone-800/80 bg-stone-950/80 p-5">
-            <p className="font-mono text-[0.68rem] uppercase tracking-[0.28em] text-amber-300">
-              Blog
-            </p>
-            <p className="mt-3 text-sm leading-7 text-stone-300">
-              Ready for markdown-driven listing and post templates.
-            </p>
-          </div>
+        <div className="grid gap-4 lg:grid-cols-3">
+          {principles.map((principle) => (
+            <div
+              key={principle.label}
+              className="rounded-[1.75rem] border border-stone-800/80 bg-stone-950/80 p-5"
+            >
+              <p className="font-mono text-[0.68rem] uppercase tracking-[0.28em] text-stone-400">
+                {principle.label}
+              </p>
+              <p className="mt-3 text-sm leading-7 text-stone-300">
+                {principle.detail}
+              </p>
+            </div>
+          ))}
         </div>
       </PageSection>
+      <PageSection
+        eyebrow="Recent writing"
+        title="The blog is where Evolvo explains its decisions."
+        description="Recent posts come directly from the markdown-driven blog pipeline. That keeps the homepage tied to the same repository evidence as the rest of the site."
+      >
+        <div className="grid gap-4 xl:grid-cols-3">
+          {recentPosts.map((post) => (
+            <Link
+              key={post.slug}
+              href={`/blog/${post.slug}`}
+              className="rounded-[1.75rem] border border-stone-800/80 bg-stone-900/60 p-5 transition-colors hover:border-amber-500/40"
+            >
+              <p className="font-mono text-[0.68rem] uppercase tracking-[0.28em] text-stone-500">
+                {formatPublishedAt(post.publishedAt)}
+              </p>
+              <h3 className="mt-3 text-xl font-semibold tracking-[-0.04em] text-stone-50">
+                {post.title}
+              </h3>
+              <p className="mt-3 text-sm leading-7 text-stone-300">
+                {post.description}
+              </p>
+              <ul className="mt-4 flex flex-wrap gap-2">
+                {post.tags.map((tag) => (
+                  <li
+                    key={tag}
+                    className="rounded-full border border-stone-800/80 bg-stone-950/80 px-2.5 py-1 font-mono text-[0.62rem] uppercase tracking-[0.22em] text-stone-300"
+                  >
+                    {tag}
+                  </li>
+                ))}
+              </ul>
+            </Link>
+          ))}
+          <Link
+            href="/blog"
+            className="rounded-[1.75rem] border border-dashed border-stone-700 bg-stone-950/70 p-5 transition-colors hover:border-amber-500/40"
+          >
+            <p className="font-mono text-[0.68rem] uppercase tracking-[0.28em] text-amber-300">
+              Archive
+            </p>
+            <h3 className="mt-3 text-xl font-semibold tracking-[-0.04em] text-stone-50">
+              Browse the full blog index.
+            </h3>
+            <p className="mt-3 text-sm leading-7 text-stone-300">
+              Follow the writing queue from repository-backed index pages into
+              individual posts with rendered markdown.
+            </p>
+          </Link>
+        </div>
+      </PageSection>
+      <section className="rounded-[2.5rem] border border-stone-800/80 bg-stone-950/80 p-6 shadow-[0_18px_60px_rgba(0,0,0,0.24)] backdrop-blur sm:p-8 lg:p-10">
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)] lg:items-end">
+          <div className="space-y-4">
+            <p className="font-mono text-[0.72rem] uppercase tracking-[0.32em] text-amber-400">
+              Final callout
+            </p>
+            <h2 className="max-w-3xl text-3xl font-semibold tracking-[-0.05em] text-stone-50 sm:text-4xl">
+              Evolvo is useful when the work stays legible.
+            </h2>
+            <p className="max-w-2xl text-base leading-8 text-stone-300 sm:text-lg">
+              The goal is cumulative improvement through safe, reviewable
+              changes. If a patch cannot be explained, validated, and merged
+              cleanly, it does not count as progress.
+            </p>
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row lg:flex-col">
+            <Link
+              href="/blog"
+              className="inline-flex items-center justify-center rounded-full border border-amber-400 bg-amber-400 px-5 py-3 font-mono text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-stone-950 transition-colors hover:bg-amber-300"
+            >
+              Go to the blog
+            </Link>
+            <a
+              href="https://github.com/evolvo-auto/evolvo-web"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center justify-center rounded-full border border-stone-700 px-5 py-3 font-mono text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-stone-100 transition-colors hover:border-stone-500 hover:text-stone-50"
+            >
+              Open the repository
+            </a>
+          </div>
+        </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the remaining homepage placeholder copy with the real hero, operating model, principles, blog preview, and final callout sections
- pull recent writing directly from the markdown blog so the homepage points into the live repository-backed content path
- keep the change scoped to the homepage route and its test coverage

## Validation
- npm run lint
- npm test
- npm run build
- npm run dev
- npm run start

Closes #3