### PR TITLE
ci(repo): add pull request validation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build application
+        run: npm run build

--- a/scripts/ci-workflow.test.ts
+++ b/scripts/ci-workflow.test.ts
@@ -1,0 +1,33 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const workflowPath = path.join(
+  process.cwd(),
+  ".github",
+  "workflows",
+  "ci.yml",
+);
+
+describe("ci workflow", () => {
+  it("runs on pull requests and pushes to main", () => {
+    const workflow = fs.readFileSync(workflowPath, "utf8");
+
+    expect(workflow).toContain("pull_request:");
+    expect(workflow).toContain("push:");
+    expect(workflow).toContain("- main");
+  });
+
+  it("installs dependencies, lints, tests, and builds with npm", () => {
+    const workflow = fs.readFileSync(workflowPath, "utf8");
+
+    expect(workflow).toContain("uses: actions/checkout@v4");
+    expect(workflow).toContain("uses: actions/setup-node@v4");
+    expect(workflow).toContain("cache: npm");
+    expect(workflow).toContain("run: npm ci");
+    expect(workflow).toContain("run: npm run lint");
+    expect(workflow).toContain("run: npm test");
+    expect(workflow).toContain("run: npm run build");
+  });
+});


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs on pull requests and pushes to `main`
- install dependencies with `npm ci` and run lint, test, and production build
- add a repository test that keeps the workflow contract explicit and reviewable

## Validation
- npm run lint
- npm test
- npm run build
- npm run start

Closes #12