### PR TITLE
fix(posts): harden markdown frontmatter validation

### DIFF
--- a/lib/posts.test.ts
+++ b/lib/posts.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   formatPublishedAt,
@@ -6,6 +10,26 @@ import {
   getPostBySlug,
   getPostSlugs,
 } from "./posts";
+
+const temporaryDirectories: string[] = [];
+
+function createPostsDirectory(files: Record<string, string>): string {
+  const directoryPath = fs.mkdtempSync(path.join(os.tmpdir(), "evolvo-posts-"));
+
+  temporaryDirectories.push(directoryPath);
+
+  for (const [fileName, fileContents] of Object.entries(files)) {
+    fs.writeFileSync(path.join(directoryPath, fileName), fileContents);
+  }
+
+  return directoryPath;
+}
+
+afterEach(() => {
+  for (const directoryPath of temporaryDirectories.splice(0)) {
+    fs.rmSync(directoryPath, { recursive: true, force: true });
+  }
+});
 
 describe("posts", () => {
   it("loads markdown post summaries sorted from newest to oldest", () => {
@@ -37,5 +61,71 @@ describe("posts", () => {
 
   it("formats publication dates for display", () => {
     expect(formatPublishedAt("2026-03-05")).toBe("March 5, 2026");
+  });
+
+  it("fails when a required frontmatter field is missing", () => {
+    const directoryPath = createPostsDirectory({
+      "missing-title.md": `---
+description: Missing a title
+publishedAt: 2026-03-05
+slug: missing-title
+tags:
+  - validation
+---
+
+Body`,
+    });
+
+    expect(() => getAllPosts(directoryPath)).toThrow(
+      'Post "missing-title" is missing required frontmatter field "title".',
+    );
+  });
+
+  it("fails when publishedAt is not a strict calendar date", () => {
+    const directoryPath = createPostsDirectory({
+      "invalid-date.md": `---
+title: Invalid date
+description: Uses the wrong date format
+publishedAt: 2026/03/05
+slug: invalid-date
+tags:
+  - validation
+---
+
+Body`,
+    });
+
+    expect(() => getAllPosts(directoryPath)).toThrow(
+      'Post "invalid-date" has invalid publishedAt "2026/03/05". Expected YYYY-MM-DD.',
+    );
+  });
+
+  it("fails when two posts resolve to the same slug", () => {
+    const directoryPath = createPostsDirectory({
+      "case-study.md": `---
+title: Lowercase slug
+description: First post
+publishedAt: 2026-03-05
+slug: case-study
+tags:
+  - validation
+---
+
+Body`,
+      "Case-Study.md": `---
+title: Uppercase slug
+description: Second post
+publishedAt: 2026-03-06
+slug: Case-Study
+tags:
+  - validation
+---
+
+Body`,
+    });
+
+    expect(() => getAllPosts(directoryPath)).toThrow(
+      'Posts "Case-Study" and "case-study" resolve to duplicate slug "case-study". Slugs must be unique.',
+    );
   });
 });

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import matter from "gray-matter";
 
 const postsDirectory = path.join(process.cwd(), "content/posts");
+const publishedAtPattern = /^\d{4}-\d{2}-\d{2}$/;
 
 type PostFrontmatter = {
   title: string;
@@ -23,20 +24,53 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((item) => typeof item === "string");
 }
 
+function readRequiredString(
+  record: Record<string, unknown>,
+  field: "title" | "description" | "slug",
+  fileSlug: string,
+): string {
+  const value = record[field];
+
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(
+      `Post "${fileSlug}" is missing required frontmatter field "${field}".`,
+    );
+  }
+
+  return value.trim();
+}
+
 function normalizePublishedAt(value: unknown, fileSlug: string): string {
   if (typeof value === "string" && value.trim()) {
-    if (Number.isNaN(Date.parse(value))) {
-      throw new Error(`Post "${fileSlug}" has an invalid publishedAt value.`);
+    const normalizedValue = value.trim();
+
+    if (!publishedAtPattern.test(normalizedValue)) {
+      throw new Error(
+        `Post "${fileSlug}" has invalid publishedAt "${normalizedValue}". Expected YYYY-MM-DD.`,
+      );
     }
 
-    return value;
+    const parsed = new Date(`${normalizedValue}T00:00:00.000Z`);
+
+    if (
+      Number.isNaN(parsed.getTime()) ||
+      parsed.toISOString().slice(0, 10) !== normalizedValue
+    ) {
+      throw new Error(
+        `Post "${fileSlug}" has invalid publishedAt "${normalizedValue}". Expected a real calendar date in YYYY-MM-DD format.`,
+      );
+    }
+
+    return normalizedValue;
   }
 
   if (value instanceof Date && !Number.isNaN(value.getTime())) {
     return value.toISOString().slice(0, 10);
   }
 
-  throw new Error(`Post "${fileSlug}" is missing a valid publishedAt value.`);
+  throw new Error(
+    `Post "${fileSlug}" is missing required frontmatter field "publishedAt".`,
+  );
 }
 
 function parsePostFrontmatter(
@@ -48,43 +82,41 @@ function parsePostFrontmatter(
   }
 
   const record = data as Record<string, unknown>;
-
-  if (typeof record.title !== "string" || !record.title.trim()) {
-    throw new Error(`Post "${fileSlug}" is missing a valid title.`);
-  }
-
-  if (typeof record.description !== "string" || !record.description.trim()) {
-    throw new Error(`Post "${fileSlug}" is missing a valid description.`);
-  }
+  const title = readRequiredString(record, "title", fileSlug);
+  const description = readRequiredString(record, "description", fileSlug);
 
   const publishedAt = normalizePublishedAt(record.publishedAt, fileSlug);
+  const slug = readRequiredString(record, "slug", fileSlug);
 
-  if (typeof record.slug !== "string" || !record.slug.trim()) {
-    throw new Error(`Post "${fileSlug}" is missing a valid slug.`);
+  if (slug !== fileSlug) {
+    throw new Error(
+      `Post "${fileSlug}" has mismatched slug frontmatter "${slug}". Expected "${fileSlug}".`,
+    );
   }
 
-  if (record.slug !== fileSlug) {
+  if (record.tags === undefined) {
     throw new Error(
-      `Post "${fileSlug}" has mismatched slug frontmatter "${record.slug}".`,
+      `Post "${fileSlug}" is missing required frontmatter field "tags".`,
     );
   }
 
   if (!isStringArray(record.tags) || record.tags.length === 0) {
-    throw new Error(`Post "${fileSlug}" is missing a valid tags array.`);
+    throw new Error(
+      `Post "${fileSlug}" must provide a non-empty "tags" array.`,
+    );
   }
 
   return {
-    title: record.title,
-    description: record.description,
+    title,
+    description,
     publishedAt,
-    slug: record.slug,
+    slug,
     tags: record.tags,
   };
 }
 
-function readMarkdownFile(fileName: string): Post {
-  const filePath = path.join(postsDirectory, fileName);
-  const fileSlug = fileName.replace(/\.md$/, "");
+function readMarkdownFile(filePath: string): Post {
+  const fileSlug = path.basename(filePath).replace(/\.md$/, "");
   const source = fs.readFileSync(filePath, "utf8");
   const { data, content } = matter(source);
   const frontmatter = parsePostFrontmatter(data, fileSlug);
@@ -95,11 +127,28 @@ function readMarkdownFile(fileName: string): Post {
   };
 }
 
-export function getAllPosts(): PostSummary[] {
-  return fs
-    .readdirSync(postsDirectory)
+function assertUniqueSlugs(posts: PostSummary[]) {
+  const slugs = new Map<string, string>();
+
+  for (const post of posts) {
+    const normalizedSlug = post.slug.toLowerCase();
+    const existingPostSlug = slugs.get(normalizedSlug);
+
+    if (existingPostSlug) {
+      throw new Error(
+        `Posts "${existingPostSlug}" and "${post.slug}" resolve to duplicate slug "${normalizedSlug}". Slugs must be unique.`,
+      );
+    }
+
+    slugs.set(normalizedSlug, post.slug);
+  }
+}
+
+export function getAllPosts(directoryPath = postsDirectory): PostSummary[] {
+  const posts = fs
+    .readdirSync(directoryPath)
     .filter((fileName) => fileName.endsWith(".md"))
-    .map(readMarkdownFile)
+    .map((fileName) => readMarkdownFile(path.join(directoryPath, fileName)))
     .sort((left, right) =>
       right.publishedAt.localeCompare(left.publishedAt),
     )
@@ -110,20 +159,27 @@ export function getAllPosts(): PostSummary[] {
       slug: post.slug,
       tags: post.tags,
     }));
+
+  assertUniqueSlugs(posts);
+
+  return posts;
 }
 
-export function getPostBySlug(slug: string): Post | undefined {
-  const filePath = path.join(postsDirectory, `${slug}.md`);
+export function getPostBySlug(
+  slug: string,
+  directoryPath = postsDirectory,
+): Post | undefined {
+  const filePath = path.join(directoryPath, `${slug}.md`);
 
   if (!fs.existsSync(filePath)) {
     return undefined;
   }
 
-  return readMarkdownFile(`${slug}.md`);
+  return readMarkdownFile(filePath);
 }
 
-export function getPostSlugs(): string[] {
-  return getAllPosts().map((post) => post.slug);
+export function getPostSlugs(directoryPath = postsDirectory): string[] {
+  return getAllPosts(directoryPath).map((post) => post.slug);
 }
 
 export function formatPublishedAt(publishedAt: string): string {


### PR DESCRIPTION
## Summary
- make frontmatter validation explicit for required string fields and non-empty tags
- require strict `YYYY-MM-DD` `publishedAt` values and reject invalid calendar dates
- detect duplicate slugs case-insensitively and cover the new failure paths with temp-fixture tests

## Validation
- npm run lint
- npm test
- npm run build
- npm run start

Closes #13