### PR TITLE
feat(signups): add local email registration backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+/data/email-signups.json
 
 # misc
 .DS_Store

--- a/app/api/email-signups/route.test.ts
+++ b/app/api/email-signups/route.test.ts
@@ -1,0 +1,150 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { POST } from "./route";
+
+const originalStoragePath = process.env.EVOLVO_EMAIL_SIGNUPS_FILE;
+const temporaryDirectories: string[] = [];
+
+function setTemporaryStoragePath() {
+  const directoryPath = fs.mkdtempSync(
+    path.join(os.tmpdir(), "evolvo-email-signups-route-"),
+  );
+
+  temporaryDirectories.push(directoryPath);
+  process.env.EVOLVO_EMAIL_SIGNUPS_FILE = path.join(
+    directoryPath,
+    "email-signups.json",
+  );
+}
+
+afterEach(() => {
+  if (originalStoragePath) {
+    process.env.EVOLVO_EMAIL_SIGNUPS_FILE = originalStoragePath;
+  } else {
+    delete process.env.EVOLVO_EMAIL_SIGNUPS_FILE;
+  }
+
+  for (const directoryPath of temporaryDirectories.splice(0)) {
+    fs.rmSync(directoryPath, { recursive: true, force: true });
+  }
+});
+
+describe("POST /api/email-signups", () => {
+  it("stores valid email signups", async () => {
+    setTemporaryStoragePath();
+
+    const response = await POST(
+      new Request("http://localhost/api/email-signups", {
+        body: JSON.stringify({ email: "hello@example.com" }),
+        headers: {
+          "content-type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+    const payload = (await response.json()) as {
+      message: string;
+      ok: boolean;
+      status: string;
+    };
+
+    expect(response.status).toBe(201);
+    expect(payload).toEqual({
+      message: "You are on the list for Evolvo updates.",
+      ok: true,
+      status: "created",
+    });
+  });
+
+  it("returns a duplicate response for existing email signups", async () => {
+    setTemporaryStoragePath();
+
+    await POST(
+      new Request("http://localhost/api/email-signups", {
+        body: JSON.stringify({ email: "hello@example.com" }),
+        headers: {
+          "content-type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+
+    const response = await POST(
+      new Request("http://localhost/api/email-signups", {
+        body: JSON.stringify({ email: "HELLO@example.com" }),
+        headers: {
+          "content-type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+    const payload = (await response.json()) as {
+      message: string;
+      ok: boolean;
+      status: string;
+    };
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({
+      message: "That email is already registered for Evolvo updates.",
+      ok: true,
+      status: "duplicate",
+    });
+  });
+
+  it("rejects invalid email submissions", async () => {
+    setTemporaryStoragePath();
+
+    const response = await POST(
+      new Request("http://localhost/api/email-signups", {
+        body: JSON.stringify({ email: "not-an-email" }),
+        headers: {
+          "content-type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+    const payload = (await response.json()) as {
+      message: string;
+      ok: boolean;
+      status: string;
+    };
+
+    expect(response.status).toBe(400);
+    expect(payload).toEqual({
+      message: "Enter a valid email address.",
+      ok: false,
+      status: "invalid",
+    });
+  });
+
+  it("rejects malformed JSON payloads", async () => {
+    setTemporaryStoragePath();
+
+    const response = await POST(
+      new Request("http://localhost/api/email-signups", {
+        body: "{not-json",
+        headers: {
+          "content-type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+    const payload = (await response.json()) as {
+      message: string;
+      ok: boolean;
+      status: string;
+    };
+
+    expect(response.status).toBe(400);
+    expect(payload).toEqual({
+      message: "Send a JSON body with an email field.",
+      ok: false,
+      status: "invalid",
+    });
+  });
+});

--- a/app/api/email-signups/route.ts
+++ b/app/api/email-signups/route.ts
@@ -1,0 +1,78 @@
+import {
+  EmailSignupStorageError,
+  EmailSignupValidationError,
+  saveEmailSignup,
+} from "../../../lib/email-signups";
+
+type EmailSignupRequest = {
+  email?: unknown;
+};
+
+export async function POST(request: Request) {
+  let body: EmailSignupRequest;
+
+  try {
+    body = (await request.json()) as EmailSignupRequest;
+  } catch {
+    return Response.json(
+      {
+        message: "Send a JSON body with an email field.",
+        ok: false,
+        status: "invalid",
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = saveEmailSignup(body?.email);
+
+    if (result.status === "duplicate") {
+      return Response.json({
+        message: "That email is already registered for Evolvo updates.",
+        ok: true,
+        status: "duplicate",
+      });
+    }
+
+    return Response.json(
+      {
+        message: "You are on the list for Evolvo updates.",
+        ok: true,
+        status: "created",
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    if (error instanceof EmailSignupValidationError) {
+      return Response.json(
+        {
+          message: error.message,
+          ok: false,
+          status: "invalid",
+        },
+        { status: 400 },
+      );
+    }
+
+    if (error instanceof EmailSignupStorageError) {
+      return Response.json(
+        {
+          message: "Email signup storage is unavailable right now.",
+          ok: false,
+          status: "error",
+        },
+        { status: 500 },
+      );
+    }
+
+    return Response.json(
+      {
+        message: "Unable to store your email right now.",
+        ok: false,
+        status: "error",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -29,6 +29,7 @@ describe("HomePage", () => {
     expect(markup).toContain("Operating model");
     expect(markup).toContain("href=\"/blog\"");
     expect(markup).toContain(firstPost.title);
+    expect(markup).toContain("Get email updates");
     expect(markup).toContain("Open the repository");
   });
 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import EmailSignupForm from "../components/site/EmailSignupForm";
 import PageSection from "../components/site/PageSection";
 import { formatPublishedAt, getAllPosts } from "../lib/posts";
 
@@ -248,21 +249,24 @@ export default function HomePage() {
               cleanly, it does not count as progress.
             </p>
           </div>
-          <div className="flex flex-col gap-3 sm:flex-row lg:flex-col">
-            <Link
-              href="/blog"
-              className="inline-flex items-center justify-center rounded-full border border-amber-400 bg-amber-400 px-5 py-3 font-mono text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-stone-950 transition-colors hover:bg-amber-300"
-            >
-              Go to the blog
-            </Link>
-            <a
-              href="https://github.com/evolvo-auto/evolvo-web"
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center justify-center rounded-full border border-stone-700 px-5 py-3 font-mono text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-stone-100 transition-colors hover:border-stone-500 hover:text-stone-50"
-            >
-              Open the repository
-            </a>
+          <div className="space-y-4">
+            <EmailSignupForm />
+            <div className="flex flex-col gap-3 sm:flex-row lg:flex-col">
+              <Link
+                href="/blog"
+                className="inline-flex items-center justify-center rounded-full border border-amber-400 bg-amber-400 px-5 py-3 font-mono text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-stone-950 transition-colors hover:bg-amber-300"
+              >
+                Go to the blog
+              </Link>
+              <a
+                href="https://github.com/evolvo-auto/evolvo-web"
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center justify-center rounded-full border border-stone-700 px-5 py-3 font-mono text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-stone-100 transition-colors hover:border-stone-500 hover:text-stone-50"
+              >
+                Open the repository
+              </a>
+            </div>
           </div>
         </div>
       </section>

--- a/components/site/EmailSignupForm.test.tsx
+++ b/components/site/EmailSignupForm.test.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import EmailSignupForm from "./EmailSignupForm";
+
+describe("EmailSignupForm", () => {
+  it("renders the signup prompt and email field", () => {
+    const markup = renderToStaticMarkup(<EmailSignupForm />);
+
+    expect(markup).toContain("Get email updates");
+    expect(markup).toContain("name=\"email\"");
+    expect(markup).toContain("type=\"email\"");
+    expect(markup).toContain("Register email");
+  });
+});

--- a/components/site/EmailSignupForm.tsx
+++ b/components/site/EmailSignupForm.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useState, useTransition } from "react";
+
+type SubmissionState = {
+  message: string;
+  tone: "error" | "idle" | "success";
+};
+
+export default function EmailSignupForm() {
+  const [email, setEmail] = useState("");
+  const [submissionState, setSubmissionState] = useState<SubmissionState>({
+    message: "",
+    tone: "idle",
+  });
+  const [isPending, startTransition] = useTransition();
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const submittedEmail = email;
+
+    startTransition(async () => {
+      try {
+        const response = await fetch("/api/email-signups", {
+          body: JSON.stringify({ email: submittedEmail }),
+          headers: {
+            "content-type": "application/json",
+          },
+          method: "POST",
+        });
+        const payload = (await response.json()) as {
+          message?: string;
+          ok?: boolean;
+        };
+
+        if (!response.ok || !payload.ok) {
+          setSubmissionState({
+            message:
+              payload.message ?? "Unable to store your email right now.",
+            tone: "error",
+          });
+
+          return;
+        }
+
+        setEmail("");
+        setSubmissionState({
+          message: payload.message ?? "You are on the list for Evolvo updates.",
+          tone: "success",
+        });
+      } catch {
+        setSubmissionState({
+          message: "Unable to store your email right now.",
+          tone: "error",
+        });
+      }
+    });
+  }
+
+  return (
+    <div className="rounded-[1.75rem] border border-stone-800/80 bg-stone-900/70 p-5">
+      <p className="font-mono text-[0.68rem] uppercase tracking-[0.28em] text-amber-300">
+        Get email updates
+      </p>
+      <p className="mt-3 text-sm leading-7 text-stone-300">
+        Register for release notes and operating updates from the Evolvo queue.
+      </p>
+      <form className="mt-5 space-y-3" onSubmit={handleSubmit}>
+        <label
+          htmlFor="email-signup"
+          className="font-mono text-[0.68rem] uppercase tracking-[0.24em] text-stone-400"
+        >
+          Email address
+        </label>
+        <input
+          id="email-signup"
+          name="email"
+          type="email"
+          autoComplete="email"
+          required
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          placeholder="operator@example.com"
+          className="w-full rounded-2xl border border-stone-700 bg-stone-950 px-4 py-3 text-sm text-stone-100 outline-none transition-colors placeholder:text-stone-500 focus:border-amber-400"
+        />
+        <button
+          type="submit"
+          disabled={isPending}
+          className="inline-flex items-center justify-center rounded-full border border-amber-400 bg-amber-400 px-5 py-3 font-mono text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-stone-950 transition-colors hover:bg-amber-300 disabled:cursor-not-allowed disabled:border-stone-700 disabled:bg-stone-800 disabled:text-stone-400"
+        >
+          {isPending ? "Submitting" : "Register email"}
+        </button>
+      </form>
+      <p
+        aria-live="polite"
+        className={`mt-3 text-sm leading-7 ${
+          submissionState.tone === "error" ? "text-amber-300" : "text-stone-300"
+        }`}
+      >
+        {submissionState.message || "Submissions are stored locally on the server in v1."}
+      </p>
+    </div>
+  );
+}

--- a/lib/email-signups.test.ts
+++ b/lib/email-signups.test.ts
@@ -1,0 +1,70 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  EmailSignupStorageError,
+  EmailSignupValidationError,
+  normalizeEmail,
+  readEmailSignups,
+  saveEmailSignup,
+  validateEmailAddress,
+} from "./email-signups";
+
+const temporaryPaths: string[] = [];
+
+function createTemporaryFilePath(fileName: string) {
+  const directoryPath = fs.mkdtempSync(
+    path.join(os.tmpdir(), "evolvo-email-signups-"),
+  );
+  const filePath = path.join(directoryPath, fileName);
+
+  temporaryPaths.push(directoryPath);
+
+  return filePath;
+}
+
+afterEach(() => {
+  for (const directoryPath of temporaryPaths.splice(0)) {
+    fs.rmSync(directoryPath, { recursive: true, force: true });
+  }
+});
+
+describe("email signups", () => {
+  it("normalizes and validates email addresses", () => {
+    expect(normalizeEmail("  HELLO@EXAMPLE.COM  ")).toBe("hello@example.com");
+    expect(validateEmailAddress("  HELLO@EXAMPLE.COM  ")).toBe(
+      "hello@example.com",
+    );
+    expect(() => validateEmailAddress("not-an-email")).toThrow(
+      EmailSignupValidationError,
+    );
+  });
+
+  it("stores new signups and skips duplicate emails", () => {
+    const filePath = createTemporaryFilePath("email-signups.json");
+
+    expect(saveEmailSignup("first@example.com", filePath).status).toBe(
+      "created",
+    );
+    expect(saveEmailSignup("FIRST@example.com", filePath).status).toBe(
+      "duplicate",
+    );
+    expect(readEmailSignups(filePath)).toEqual([
+      expect.objectContaining({
+        email: "first@example.com",
+      }),
+    ]);
+  });
+
+  it("fails clearly when the storage file is malformed", () => {
+    const filePath = createTemporaryFilePath("email-signups.json");
+
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, "{not-json");
+
+    expect(() => readEmailSignups(filePath)).toThrow(EmailSignupStorageError);
+  });
+});

--- a/lib/email-signups.ts
+++ b/lib/email-signups.ts
@@ -1,0 +1,126 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export type EmailSignupRecord = {
+  email: string;
+  submittedAt: string;
+};
+
+export type EmailSignupResult = {
+  record: EmailSignupRecord;
+  status: "created" | "duplicate";
+};
+
+export class EmailSignupValidationError extends Error {}
+
+export class EmailSignupStorageError extends Error {}
+
+function getEmailSignupsFilePath() {
+  if (process.env.EVOLVO_EMAIL_SIGNUPS_FILE) {
+    return path.resolve(process.env.EVOLVO_EMAIL_SIGNUPS_FILE);
+  }
+
+  return path.join(process.cwd(), "data", "email-signups.json");
+}
+
+export function normalizeEmail(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function validateEmailAddress(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new EmailSignupValidationError("Enter a valid email address.");
+  }
+
+  const normalizedEmail = normalizeEmail(value);
+
+  if (
+    normalizedEmail.length === 0 ||
+    normalizedEmail.length > 254 ||
+    !emailPattern.test(normalizedEmail)
+  ) {
+    throw new EmailSignupValidationError("Enter a valid email address.");
+  }
+
+  return normalizedEmail;
+}
+
+function isEmailSignupRecord(value: unknown): value is EmailSignupRecord {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+
+  return (
+    typeof record.email === "string" &&
+    typeof record.submittedAt === "string" &&
+    !Number.isNaN(Date.parse(record.submittedAt))
+  );
+}
+
+export function readEmailSignups(
+  filePath = getEmailSignupsFilePath(),
+): EmailSignupRecord[] {
+  if (!fs.existsSync(filePath)) {
+    return [];
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    throw new EmailSignupStorageError(
+      `Email signup storage at "${filePath}" is not valid JSON.`,
+    );
+  }
+
+  if (!Array.isArray(parsed) || !parsed.every(isEmailSignupRecord)) {
+    throw new EmailSignupStorageError(
+      `Email signup storage at "${filePath}" has an invalid shape.`,
+    );
+  }
+
+  return parsed;
+}
+
+export function saveEmailSignup(
+  email: unknown,
+  filePath = getEmailSignupsFilePath(),
+): EmailSignupResult {
+  const normalizedEmail = validateEmailAddress(email);
+  const existingSignups = readEmailSignups(filePath);
+  const existingSignup = existingSignups.find(
+    (signup) => signup.email === normalizedEmail,
+  );
+
+  if (existingSignup) {
+    return {
+      record: existingSignup,
+      status: "duplicate",
+    };
+  }
+
+  const record = {
+    email: normalizedEmail,
+    submittedAt: new Date().toISOString(),
+  } satisfies EmailSignupRecord;
+
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+
+  const temporaryFilePath = `${filePath}.tmp`;
+
+  fs.writeFileSync(
+    temporaryFilePath,
+    JSON.stringify([...existingSignups, record], null, 2) + "\n",
+  );
+  fs.renameSync(temporaryFilePath, filePath);
+
+  return {
+    record,
+    status: "created",
+  };
+}


### PR DESCRIPTION
## Summary
- add a file-backed email signup store with normalization, validation, duplicate handling, and atomic writes
- expose a POST route at `/api/email-signups` with useful created, duplicate, and invalid responses
- wire a minimal homepage signup form to the route and ignore the local data file from git

## Validation
- npm run lint
- npm test
- npm run build
- EVOLVO_EMAIL_SIGNUPS_FILE=/tmp/evolvo-email-signups.json npm run start
- POST /api/email-signups with invalid and valid payloads against the running app

Closes #16