### PR TITLE
feat: add homepage follow-progress cta

### DIFF
--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -19,7 +19,7 @@ vi.mock("next/link", () => ({
 }));
 
 describe("HomePage", () => {
-  it("renders the homepage narrative and blog preview links", () => {
+  it("renders the homepage narrative, CTA, and blog preview links", () => {
     const [firstPost] = getAllPosts();
     const markup = renderToStaticMarkup(<HomePage />);
 
@@ -30,7 +30,9 @@ describe("HomePage", () => {
     expect(markup).toContain("Why this exists");
     expect(markup).toContain("href=\"/blog\"");
     expect(markup).toContain(firstPost.title);
-    expect(markup).toContain("Get email updates");
-    expect(markup).toContain("Open the repository");
+    expect(markup).toContain("Follow the progress");
+    expect(markup).toContain("Watch the work accumulate in public.");
+    expect(markup).toContain("Follow Evolvo&#x27;s progress");
+    expect(markup).toContain("Track the repository");
   });
 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -49,6 +49,24 @@ const principles = [
   },
 ] as const;
 
+const followChannels = [
+  {
+    label: "Update emails",
+    detail:
+      "Get concise notes when Evolvo ships accepted changes, publishes new writing, or opens the next stage of work.",
+  },
+  {
+    label: "Public writing",
+    detail:
+      "Follow the reasoning behind what survived review, what changed in the queue, and where the system is headed next.",
+  },
+  {
+    label: "Repository trail",
+    detail:
+      "Inspect the issues, pull requests, and merged diffs that back up the public claims.",
+  },
+] as const;
+
 export default function HomePage() {
   const recentPosts = getAllPosts().slice(0, 3);
 
@@ -239,16 +257,32 @@ export default function HomePage() {
         <div className="grid gap-8 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)] lg:items-end">
           <div className="space-y-4">
             <p className="font-mono text-[0.72rem] uppercase tracking-[0.32em] text-amber-400">
-              Final callout
+              Follow the progress
             </p>
             <h2 className="max-w-3xl text-3xl font-semibold tracking-[-0.05em] text-stone-50 sm:text-4xl">
-              Evolvo is useful when the work stays legible.
+              Watch the work accumulate in public.
             </h2>
             <p className="max-w-2xl text-base leading-8 text-stone-300 sm:text-lg">
-              The goal is cumulative improvement through safe, reviewable
-              changes. If a patch cannot be explained, validated, and merged
-              cleanly, it does not count as progress.
+              If Evolvo is about delegation through reviewable software work,
+              the next step should be equally concrete. Join the update list,
+              follow the writing, or inspect the repository as accepted changes
+              continue to land.
             </p>
+            <div className="grid gap-3 pt-2 sm:grid-cols-3">
+              {followChannels.map((channel) => (
+                <div
+                  key={channel.label}
+                  className="rounded-[1.5rem] border border-stone-800/80 bg-stone-900/60 p-4"
+                >
+                  <p className="font-mono text-[0.68rem] uppercase tracking-[0.28em] text-amber-300">
+                    {channel.label}
+                  </p>
+                  <p className="mt-3 text-sm leading-7 text-stone-300">
+                    {channel.detail}
+                  </p>
+                </div>
+              ))}
+            </div>
           </div>
           <div className="space-y-4">
             <EmailSignupForm />
@@ -257,7 +291,7 @@ export default function HomePage() {
                 href="/blog"
                 className="inline-flex items-center justify-center rounded-full border border-amber-400 bg-amber-400 px-5 py-3 font-mono text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-stone-950 transition-colors hover:bg-amber-300"
               >
-                Go to the blog
+                Follow the writing
               </Link>
               <a
                 href="https://github.com/evolvo-auto/evolvo-web"
@@ -265,7 +299,7 @@ export default function HomePage() {
                 rel="noreferrer"
                 className="inline-flex items-center justify-center rounded-full border border-stone-700 px-5 py-3 font-mono text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-stone-100 transition-colors hover:border-stone-500 hover:text-stone-50"
               >
-                Open the repository
+                Track the repository
               </a>
             </div>
           </div>

--- a/components/site/EmailSignupForm.test.tsx
+++ b/components/site/EmailSignupForm.test.tsx
@@ -8,9 +8,9 @@ describe("EmailSignupForm", () => {
   it("renders the signup prompt and email field", () => {
     const markup = renderToStaticMarkup(<EmailSignupForm />);
 
-    expect(markup).toContain("Get email updates");
+    expect(markup).toContain("Follow Evolvo&#x27;s progress");
     expect(markup).toContain("name=\"email\"");
     expect(markup).toContain("type=\"email\"");
-    expect(markup).toContain("Register email");
+    expect(markup).toContain("Join updates");
   });
 });

--- a/components/site/EmailSignupForm.tsx
+++ b/components/site/EmailSignupForm.tsx
@@ -62,10 +62,11 @@ export default function EmailSignupForm() {
   return (
     <div className="rounded-[1.75rem] border border-stone-800/80 bg-stone-900/70 p-5">
       <p className="font-mono text-[0.68rem] uppercase tracking-[0.28em] text-amber-300">
-        Get email updates
+        Follow Evolvo&apos;s progress
       </p>
       <p className="mt-3 text-sm leading-7 text-stone-300">
-        Register for release notes and operating updates from the Evolvo queue.
+        Get concise updates when accepted changes land, new writing is
+        published, or the next stage of work opens.
       </p>
       <form className="mt-5 space-y-3" onSubmit={handleSubmit}>
         <label
@@ -90,7 +91,7 @@ export default function EmailSignupForm() {
           disabled={isPending}
           className="inline-flex items-center justify-center rounded-full border border-amber-400 bg-amber-400 px-5 py-3 font-mono text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-stone-950 transition-colors hover:bg-amber-300 disabled:cursor-not-allowed disabled:border-stone-700 disabled:bg-stone-800 disabled:text-stone-400"
         >
-          {isPending ? "Submitting" : "Register email"}
+          {isPending ? "Submitting" : "Join updates"}
         </button>
       </form>
       <p
@@ -99,7 +100,8 @@ export default function EmailSignupForm() {
           submissionState.tone === "error" ? "text-amber-300" : "text-stone-300"
         }`}
       >
-        {submissionState.message || "Submissions are stored locally on the server in v1."}
+        {submissionState.message ||
+          "Expect occasional notes focused on shipped work, not marketing noise."}
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
- turn the existing homepage footer callout into a dedicated follow-progress CTA section
- make the email signup card more explicit about what visitors will receive
- keep the CTA aligned with Evolvo's evidence-first tone while giving clearer next steps

Closes #23
