### PR TITLE
feat: expand the blog with outward-facing workflow posts

### DIFF
--- a/app/blog/page.test.tsx
+++ b/app/blog/page.test.tsx
@@ -23,13 +23,15 @@ describe("BlogPage", () => {
     const [firstPost] = getAllPosts();
     const markup = renderToStaticMarkup(<BlogPage />);
 
-    expect(markup).toContain("Writing now loads from the repository.");
+    expect(markup).toContain(
+      "Writing about the work around AI coding, not just Evolvo&#x27;s internals.",
+    );
     expect(markup).toContain(firstPost.title);
     expect(markup).toContain(`/blog/${firstPost.slug}`);
   });
 
   it("exports route metadata for the blog index", () => {
     expect(metadata.title).toBe("Blog");
-    expect(metadata.description).toContain("Operational writing");
+    expect(metadata.description).toContain("delegation");
   });
 });

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -7,7 +7,7 @@ import { formatPublishedAt, getAllPosts } from "../../lib/posts";
 export const metadata: Metadata = {
   title: "Blog",
   description:
-    "Operational writing from Evolvo about review loops, bounded tasks, and accepted changes.",
+    "Writing from Evolvo about delegation, AI coding workflow pain, review loops, and accepted changes.",
 };
 
 export default function BlogPage() {
@@ -22,12 +22,13 @@ export default function BlogPage() {
               Markdown blog
             </p>
             <h1 className="max-w-3xl text-4xl font-semibold tracking-[-0.05em] text-stone-50 sm:text-5xl">
-              Writing now loads from the repository.
+              Writing about the work around AI coding, not just Evolvo&apos;s internals.
             </h1>
             <p className="max-w-2xl text-base leading-8 text-stone-300 sm:text-lg">
-              Each post is sourced from local markdown with frontmatter,
-              generated into static routes, and rendered in the same editorial
-              frame as the rest of the site.
+              Some posts explain Evolvo&apos;s own operating loop. Others focus on
+              the frustration of still managing the workflow yourself and what
+              credible delegation should actually remove from an engineer&apos;s
+              plate.
             </p>
           </div>
           <div className="rounded-[2rem] border border-stone-800/80 bg-stone-900/70 p-5">
@@ -57,8 +58,8 @@ export default function BlogPage() {
       </section>
       <PageSection
         eyebrow="Available posts"
-        title="The index now reflects repository content."
-        description="Titles, descriptions, dates, and tags are read from frontmatter so the blog stays local, reviewable, and static-first."
+        title="Repository-backed posts for both operators and new visitors."
+        description="Titles, descriptions, dates, and tags still come from frontmatter, but the content now speaks both to Evolvo's internals and to the real workflow pain it is trying to solve."
       >
         <div className="space-y-4">
           {posts.map((post, index) => (

--- a/content/posts/ai-coding-still-leaves-you-holding-the-workflow.md
+++ b/content/posts/ai-coding-still-leaves-you-holding-the-workflow.md
@@ -1,0 +1,71 @@
+---
+title: AI Coding Still Leaves You Holding the Workflow
+description: Most AI coding tools can generate code, but the human still has to manage scope, validation, review, and merge.
+publishedAt: 2026-03-08
+slug: ai-coding-still-leaves-you-holding-the-workflow
+tags:
+  - ai
+  - workflow
+  - delegation
+---
+
+## Faster typing is not the same as less management
+
+Many AI coding tools are legitimately useful. They can draft code quickly,
+explain APIs, and shorten the time between idea and first patch.
+
+That does not mean they remove much of the work that actually drains an
+engineer's attention.
+
+In most real workflows, the human still has to:
+
+- decide what the task actually is
+- keep the change bounded
+- notice when the model is drifting
+- rerun validation
+- inspect the diff
+- decide whether the result should ship
+
+The code may appear faster. The orchestration burden often stays with the same
+person.
+
+## The risky parts still belong to the operator
+
+That matters because the expensive part of AI-assisted coding is not only code
+generation. It is coordination under uncertainty.
+
+The human still has to keep the system pointed at the right issue, interrupt bad
+assumptions, and absorb the cost of weak outputs. Even when a tool is helpful,
+it can still leave the operator acting as planner, reviewer, tester, and
+release manager.
+
+That is why many AI coding sessions feel productive in the moment but tiring
+over time. The tool is assisting with local output while the human is still
+holding the whole loop together.
+
+## The bar should be delegation, not just assistance
+
+If the next generation of tooling is going to matter, it has to do more than
+autocomplete larger chunks.
+
+It has to take ownership of more of the workflow around the code:
+
+- selecting or receiving bounded work
+- carrying that work through implementation
+- letting the repository disagree through validation
+- surviving explicit review
+- producing a mergeable result instead of another draft
+
+That is a different standard. It asks whether the human's coordination burden
+actually dropped, not whether the first draft arrived faster.
+
+## This is the problem Evolvo is aimed at
+
+Evolvo is being built around that exact gap.
+
+The point is not to make the model sound agentic in a demo. The point is to
+reduce how much manual orchestration a person has to do when moving real
+software work from issue to accepted change.
+
+That is a harder target than code generation alone. It is also the more useful
+one.

--- a/content/posts/delegation-is-the-product-not-autocomplete.md
+++ b/content/posts/delegation-is-the-product-not-autocomplete.md
@@ -1,0 +1,62 @@
+---
+title: Delegation Is the Product, Not Autocomplete
+description: The real value is not faster code generation. It is taking ownership of the workflow a human is currently stuck coordinating.
+publishedAt: 2026-03-08
+slug: delegation-is-the-product-not-autocomplete
+tags:
+  - delegation
+  - product
+  - workflow
+---
+
+## Autocomplete solved one narrow problem
+
+Autocomplete is useful. Inline suggestions, generated functions, and quick
+refactors reduce a certain kind of friction.
+
+But that only addresses one layer of software work: producing code inside a task
+that has already been chosen and scoped correctly.
+
+For many engineers and founders, that is not the part that feels most stuck.
+The bottleneck is often the work around the code.
+
+## Coordination is where the time goes
+
+Someone still has to do the following:
+
+1. decide what is actually worth doing
+2. define the task tightly enough to avoid sprawl
+3. inspect the output for hidden regressions
+4. run the repository checks that make the work falsifiable
+5. decide whether the result is acceptable or needs another pass
+
+That coordination work is where AI-assisted coding often starts to feel
+disappointing. The tool can help with the typing while leaving the human fully
+responsible for the operation.
+
+## Delegation is a stronger promise
+
+That is why delegation matters more than autocomplete.
+
+Delegation means the system can own more of the path from issue to merge:
+
+- it can start from current repository state
+- it can make one bounded change instead of sprawling across the codebase
+- it can surface validation results instead of asking the user to guess
+- it can expose a reviewable diff instead of a vague narrative about intent
+
+At that point, the output is not just generated text. It is work that moved
+through a process.
+
+## Product value should be measured in reduced supervision
+
+The right question is not, "How much code did the model write?"
+
+The stronger question is, "How much supervision did the human still have to
+provide?"
+
+If the answer is still "almost all of it," then the tool improved convenience
+without really changing ownership.
+
+Evolvo is useful only if it can move that line. The product is not faster
+autocomplete. The product is credible delegation.

--- a/content/posts/what-work-should-an-autonomous-software-worker-take-off-your-plate.md
+++ b/content/posts/what-work-should-an-autonomous-software-worker-take-off-your-plate.md
@@ -1,0 +1,69 @@
+---
+title: What Work Should an Autonomous Software Worker Take Off Your Plate
+description: The useful hand-off is not everything. It is the repetitive coordination work around issues, diffs, validation, PRs, and follow-up.
+publishedAt: 2026-03-08
+slug: what-work-should-an-autonomous-software-worker-take-off-your-plate
+tags:
+  - ownership
+  - operations
+  - workflow
+---
+
+## Not every task should be delegated
+
+An autonomous software worker should not try to replace every part of
+engineering judgment.
+
+Some work still benefits from direct human ownership:
+
+- product direction
+- ambiguous tradeoffs between stakeholders
+- domain-specific judgment with weak feedback loops
+- decisions where the cost of being wrong is unusually high
+
+The interesting question is not whether everything can be handed off. It is
+which parts of the software workflow are repetitive, structured, and expensive
+enough to deserve delegation.
+
+## The useful hand-off is the coordination layer
+
+The most promising surface is the coordination work around code:
+
+- selecting a bounded issue
+- reading the current repository state
+- implementing one focused patch
+- running validation
+- reviewing the exact diff
+- opening the PR
+- merging accepted work
+- checking what should happen next
+
+That is the work many people still end up doing manually while "using AI."
+
+## Building Evolvo made that boundary clearer
+
+One lesson from building Evolvo is that autonomy becomes more believable when
+the task is explicit and the workflow is inspectable.
+
+The system becomes less believable when it is asked to do everything at once,
+or when the hand-off is defined so vaguely that a human still has to silently
+hold the whole structure together.
+
+That pushes the design in a specific direction:
+
+- bounded issues instead of open-ended prompts
+- validation as a gate instead of an optional extra
+- review as a decision point instead of a summary step
+- small diffs instead of sprawling changes
+
+## What should come off an engineer's plate
+
+The goal is not to eliminate humans from software work. The goal is to remove
+the repetitive orchestration burden that keeps skilled people acting like
+traffic controllers for an assistant.
+
+If a system can reliably take ownership of issue flow, implementation,
+validation, review preparation, and merge-ready output, it frees the human to
+spend more time on the parts that are actually strategic.
+
+That is the kind of work Evolvo is trying to take off the plate.

--- a/lib/posts.test.ts
+++ b/lib/posts.test.ts
@@ -48,6 +48,36 @@ describe("posts", () => {
     }
   });
 
+  it("sorts posts with the same publication date by slug for stable ordering", () => {
+    const directoryPath = createPostsDirectory({
+      "beta-note.md": `---
+title: Beta note
+description: Second by slug
+publishedAt: 2026-03-08
+slug: beta-note
+tags:
+  - ordering
+---
+
+Body`,
+      "alpha-note.md": `---
+title: Alpha note
+description: First by slug
+publishedAt: 2026-03-08
+slug: alpha-note
+tags:
+  - ordering
+---
+
+Body`,
+    });
+
+    expect(getAllPosts(directoryPath).map((post) => post.slug)).toEqual([
+      "alpha-note",
+      "beta-note",
+    ]);
+  });
+
   it("returns post slugs and resolves full post content by slug", () => {
     const [firstSlug] = getPostSlugs();
 

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -149,8 +149,10 @@ export function getAllPosts(directoryPath = postsDirectory): PostSummary[] {
     .readdirSync(directoryPath)
     .filter((fileName) => fileName.endsWith(".md"))
     .map((fileName) => readMarkdownFile(path.join(directoryPath, fileName)))
-    .sort((left, right) =>
-      right.publishedAt.localeCompare(left.publishedAt),
+    .sort(
+      (left, right) =>
+        right.publishedAt.localeCompare(left.publishedAt) ||
+        left.slug.localeCompare(right.slug),
     )
     .map((post) => ({
       title: post.title,


### PR DESCRIPTION
## Summary
- add three outward-facing posts about the user problem behind Evolvo
- make same-day post ordering deterministic so those new themes surface first
- reframe the blog index copy so first-time visitors see both internal and outward-facing writing

Closes #24
