### PR TITLE
fix: stabilize blog publish date formatting in UTC

### DIFF
--- a/lib/posts.test.ts
+++ b/lib/posts.test.ts
@@ -93,6 +93,24 @@ Body`,
     expect(formatPublishedAt("2026-03-05")).toBe("March 5, 2026");
   });
 
+  it("formats publication dates consistently across local timezones", () => {
+    const originalTimeZone = process.env.TZ;
+
+    try {
+      process.env.TZ = "America/Los_Angeles";
+      expect(formatPublishedAt("2026-03-05")).toBe("March 5, 2026");
+
+      process.env.TZ = "Pacific/Kiritimati";
+      expect(formatPublishedAt("2026-03-05")).toBe("March 5, 2026");
+    } finally {
+      if (originalTimeZone === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = originalTimeZone;
+      }
+    }
+  });
+
   it("fails when a required frontmatter field is missing", () => {
     const directoryPath = createPostsDirectory({
       "missing-title.md": `---

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -189,5 +189,6 @@ export function formatPublishedAt(publishedAt: string): string {
     month: "long",
     day: "numeric",
     year: "numeric",
+    timeZone: "UTC",
   }).format(new Date(publishedAt));
 }


### PR DESCRIPTION
## Summary
- force `formatPublishedAt` to render blog dates in UTC
- add a regression test that switches local `TZ` settings and asserts the rendered date stays stable

Closes #32