### PR TITLE
feat: move email signups to database-backed storage

### DIFF
--- a/app/api/email-signups/route.test.ts
+++ b/app/api/email-signups/route.test.ts
@@ -1,41 +1,41 @@
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { afterEach, describe, expect, it } from "vitest";
+const {
+  MockEmailSignupStorageError,
+  MockEmailSignupValidationError,
+  saveEmailSignup,
+} = vi.hoisted(() => {
+  class MockEmailSignupValidationError extends Error {}
+  class MockEmailSignupStorageError extends Error {}
+
+  return {
+    MockEmailSignupStorageError,
+    MockEmailSignupValidationError,
+    saveEmailSignup: vi.fn(),
+  };
+});
+
+vi.mock("../../../lib/email-signups", () => ({
+  EmailSignupStorageError: MockEmailSignupStorageError,
+  EmailSignupValidationError: MockEmailSignupValidationError,
+  saveEmailSignup,
+}));
 
 import { POST } from "./route";
 
-const originalStoragePath = process.env.EVOLVO_EMAIL_SIGNUPS_FILE;
-const temporaryDirectories: string[] = [];
-
-function setTemporaryStoragePath() {
-  const directoryPath = fs.mkdtempSync(
-    path.join(os.tmpdir(), "evolvo-email-signups-route-"),
-  );
-
-  temporaryDirectories.push(directoryPath);
-  process.env.EVOLVO_EMAIL_SIGNUPS_FILE = path.join(
-    directoryPath,
-    "email-signups.json",
-  );
-}
-
-afterEach(() => {
-  if (originalStoragePath) {
-    process.env.EVOLVO_EMAIL_SIGNUPS_FILE = originalStoragePath;
-  } else {
-    delete process.env.EVOLVO_EMAIL_SIGNUPS_FILE;
-  }
-
-  for (const directoryPath of temporaryDirectories.splice(0)) {
-    fs.rmSync(directoryPath, { recursive: true, force: true });
-  }
-});
-
 describe("POST /api/email-signups", () => {
+  beforeEach(() => {
+    saveEmailSignup.mockReset();
+  });
+
   it("stores valid email signups", async () => {
-    setTemporaryStoragePath();
+    saveEmailSignup.mockResolvedValue({
+      record: {
+        email: "hello@example.com",
+        submittedAt: "2026-03-08T00:00:00.000Z",
+      },
+      status: "created",
+    });
 
     const response = await POST(
       new Request("http://localhost/api/email-signups", {
@@ -52,26 +52,23 @@ describe("POST /api/email-signups", () => {
       status: string;
     };
 
+    expect(saveEmailSignup).toHaveBeenCalledWith("hello@example.com");
     expect(response.status).toBe(201);
     expect(payload).toEqual({
-      message: "You are on the list for Evolvo updates.",
+      message: "Thanks, you are on the list for Evolvo updates.",
       ok: true,
       status: "created",
     });
   });
 
   it("returns a duplicate response for existing email signups", async () => {
-    setTemporaryStoragePath();
-
-    await POST(
-      new Request("http://localhost/api/email-signups", {
-        body: JSON.stringify({ email: "hello@example.com" }),
-        headers: {
-          "content-type": "application/json",
-        },
-        method: "POST",
-      }),
-    );
+    saveEmailSignup.mockResolvedValue({
+      record: {
+        email: "hello@example.com",
+        submittedAt: "2026-03-08T00:00:00.000Z",
+      },
+      status: "duplicate",
+    });
 
     const response = await POST(
       new Request("http://localhost/api/email-signups", {
@@ -88,16 +85,19 @@ describe("POST /api/email-signups", () => {
       status: string;
     };
 
+    expect(saveEmailSignup).toHaveBeenCalledWith("HELLO@example.com");
     expect(response.status).toBe(200);
     expect(payload).toEqual({
-      message: "That email is already registered for Evolvo updates.",
+      message: "You are already on the list for Evolvo updates.",
       ok: true,
       status: "duplicate",
     });
   });
 
   it("rejects invalid email submissions", async () => {
-    setTemporaryStoragePath();
+    saveEmailSignup.mockRejectedValue(
+      new MockEmailSignupValidationError("Enter a valid email address."),
+    );
 
     const response = await POST(
       new Request("http://localhost/api/email-signups", {
@@ -123,8 +123,6 @@ describe("POST /api/email-signups", () => {
   });
 
   it("rejects malformed JSON payloads", async () => {
-    setTemporaryStoragePath();
-
     const response = await POST(
       new Request("http://localhost/api/email-signups", {
         body: "{not-json",
@@ -140,11 +138,40 @@ describe("POST /api/email-signups", () => {
       status: string;
     };
 
+    expect(saveEmailSignup).not.toHaveBeenCalled();
     expect(response.status).toBe(400);
     expect(payload).toEqual({
       message: "Send a JSON body with an email field.",
       ok: false,
       status: "invalid",
+    });
+  });
+
+  it("returns a storage error when persistence fails", async () => {
+    saveEmailSignup.mockRejectedValue(
+      new MockEmailSignupStorageError("Email signup storage is unavailable right now."),
+    );
+
+    const response = await POST(
+      new Request("http://localhost/api/email-signups", {
+        body: JSON.stringify({ email: "hello@example.com" }),
+        headers: {
+          "content-type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+    const payload = (await response.json()) as {
+      message: string;
+      ok: boolean;
+      status: string;
+    };
+
+    expect(response.status).toBe(500);
+    expect(payload).toEqual({
+      message: "Email signup storage is unavailable right now.",
+      ok: false,
+      status: "error",
     });
   });
 });

--- a/app/api/email-signups/route.ts
+++ b/app/api/email-signups/route.ts
@@ -25,11 +25,11 @@ export async function POST(request: Request) {
   }
 
   try {
-    const result = saveEmailSignup(body?.email);
+    const result = await saveEmailSignup(body?.email);
 
     if (result.status === "duplicate") {
       return Response.json({
-        message: "That email is already registered for Evolvo updates.",
+        message: "You are already on the list for Evolvo updates.",
         ok: true,
         status: "duplicate",
       });
@@ -37,7 +37,7 @@ export async function POST(request: Request) {
 
     return Response.json(
       {
-        message: "You are on the list for Evolvo updates.",
+        message: "Thanks, you are on the list for Evolvo updates.",
         ok: true,
         status: "created",
       },

--- a/lib/email-signups.test.ts
+++ b/lib/email-signups.test.ts
@@ -1,8 +1,4 @@
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
-
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import {
   EmailSignupStorageError,
@@ -13,24 +9,35 @@ import {
   validateEmailAddress,
 } from "./email-signups";
 
-const temporaryPaths: string[] = [];
+type EmailSignupRecord = {
+  email: string;
+  submittedAt: string;
+};
 
-function createTemporaryFilePath(fileName: string) {
-  const directoryPath = fs.mkdtempSync(
-    path.join(os.tmpdir(), "evolvo-email-signups-"),
-  );
-  const filePath = path.join(directoryPath, fileName);
+function createInMemoryStore(initialRecords: EmailSignupRecord[] = []) {
+  const records = [...initialRecords];
 
-  temporaryPaths.push(directoryPath);
+  return {
+    async ensureSchema() {
+      return undefined;
+    },
+    async findSignupByEmail(email: string) {
+      return records.find((record) => record.email === email);
+    },
+    async insertSignup(record: EmailSignupRecord) {
+      if (records.some((existingRecord) => existingRecord.email === record.email)) {
+        return undefined;
+      }
 
-  return filePath;
+      records.push(record);
+
+      return record;
+    },
+    async listSignups() {
+      return [...records];
+    },
+  };
 }
-
-afterEach(() => {
-  for (const directoryPath of temporaryPaths.splice(0)) {
-    fs.rmSync(directoryPath, { recursive: true, force: true });
-  }
-});
 
 describe("email signups", () => {
   it("normalizes and validates email addresses", () => {
@@ -43,28 +50,43 @@ describe("email signups", () => {
     );
   });
 
-  it("stores new signups and skips duplicate emails", () => {
-    const filePath = createTemporaryFilePath("email-signups.json");
+  it("stores new signups and skips duplicate emails", async () => {
+    const store = createInMemoryStore();
 
-    expect(saveEmailSignup("first@example.com", filePath).status).toBe(
+    expect((await saveEmailSignup("first@example.com", store)).status).toBe(
       "created",
     );
-    expect(saveEmailSignup("FIRST@example.com", filePath).status).toBe(
+    expect((await saveEmailSignup("FIRST@example.com", store)).status).toBe(
       "duplicate",
     );
-    expect(readEmailSignups(filePath)).toEqual([
+    expect(await readEmailSignups(store)).toEqual([
       expect.objectContaining({
         email: "first@example.com",
       }),
     ]);
   });
 
-  it("fails clearly when the storage file is malformed", () => {
-    const filePath = createTemporaryFilePath("email-signups.json");
+  it("wraps store failures as storage errors", async () => {
+    const failingStore = {
+      async ensureSchema() {
+        throw new Error("database offline");
+      },
+      async findSignupByEmail() {
+        return undefined;
+      },
+      async insertSignup() {
+        return undefined;
+      },
+      async listSignups() {
+        throw new Error("database offline");
+      },
+    };
 
-    fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    fs.writeFileSync(filePath, "{not-json");
-
-    expect(() => readEmailSignups(filePath)).toThrow(EmailSignupStorageError);
+    await expect(saveEmailSignup("first@example.com", failingStore)).rejects.toThrow(
+      EmailSignupStorageError,
+    );
+    await expect(readEmailSignups(failingStore)).rejects.toThrow(
+      EmailSignupStorageError,
+    );
   });
 });

--- a/lib/email-signups.ts
+++ b/lib/email-signups.ts
@@ -1,7 +1,18 @@
-import fs from "node:fs";
-import path from "node:path";
+import postgres from "postgres";
 
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type EmailSignupRow = {
+  email: string;
+  submitted_at: Date | string;
+};
+
+type EmailSignupsStore = {
+  ensureSchema(): Promise<void>;
+  findSignupByEmail(email: string): Promise<EmailSignupRecord | undefined>;
+  insertSignup(record: EmailSignupRecord): Promise<EmailSignupRecord | undefined>;
+  listSignups(): Promise<EmailSignupRecord[]>;
+};
 
 export type EmailSignupRecord = {
   email: string;
@@ -17,12 +28,106 @@ export class EmailSignupValidationError extends Error {}
 
 export class EmailSignupStorageError extends Error {}
 
-function getEmailSignupsFilePath() {
-  if (process.env.EVOLVO_EMAIL_SIGNUPS_FILE) {
-    return path.resolve(process.env.EVOLVO_EMAIL_SIGNUPS_FILE);
+let cachedEmailSignupsStore: EmailSignupsStore | undefined;
+
+function toEmailSignupRecord(row: EmailSignupRow): EmailSignupRecord {
+  return {
+    email: row.email,
+    submittedAt: new Date(row.submitted_at).toISOString(),
+  };
+}
+
+function getDatabaseUrl(): string {
+  const databaseUrl = process.env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    throw new EmailSignupStorageError(
+      "Email signup storage is unavailable right now.",
+    );
   }
 
-  return path.join(process.cwd(), "data", "email-signups.json");
+  return databaseUrl;
+}
+
+function createEmailSignupsStore(): EmailSignupsStore {
+  const sql = postgres(getDatabaseUrl(), {
+    max: 1,
+    prepare: false,
+  });
+  let schemaReadyPromise: Promise<void> | undefined;
+
+  async function ensureSchema() {
+    schemaReadyPromise ??= sql`
+      CREATE TABLE IF NOT EXISTS email_signups (
+        email TEXT PRIMARY KEY,
+        submitted_at TIMESTAMPTZ NOT NULL
+      )
+    `
+      .then(() => undefined)
+      .catch((error: unknown) => {
+        schemaReadyPromise = undefined;
+        throw error;
+      });
+
+    await schemaReadyPromise;
+  }
+
+  return {
+    async ensureSchema() {
+      await ensureSchema();
+    },
+    async findSignupByEmail(email: string) {
+      await ensureSchema();
+
+      const [row] = await sql<EmailSignupRow[]>`
+        SELECT email, submitted_at
+        FROM email_signups
+        WHERE email = ${email}
+        LIMIT 1
+      `;
+
+      return row ? toEmailSignupRecord(row) : undefined;
+    },
+    async insertSignup(record: EmailSignupRecord) {
+      await ensureSchema();
+
+      const [row] = await sql<EmailSignupRow[]>`
+        INSERT INTO email_signups (email, submitted_at)
+        VALUES (${record.email}, ${record.submittedAt}::timestamptz)
+        ON CONFLICT (email) DO NOTHING
+        RETURNING email, submitted_at
+      `;
+
+      return row ? toEmailSignupRecord(row) : undefined;
+    },
+    async listSignups() {
+      await ensureSchema();
+
+      const rows = await sql<EmailSignupRow[]>`
+        SELECT email, submitted_at
+        FROM email_signups
+        ORDER BY submitted_at ASC, email ASC
+      `;
+
+      return rows.map(toEmailSignupRecord);
+    },
+  };
+}
+
+function getEmailSignupsStore(): EmailSignupsStore {
+  cachedEmailSignupsStore ??= createEmailSignupsStore();
+
+  return cachedEmailSignupsStore;
+}
+
+function toStorageError(error: unknown): EmailSignupStorageError {
+  if (error instanceof EmailSignupStorageError) {
+    return error;
+  }
+
+  return new EmailSignupStorageError(
+    "Email signup storage is unavailable right now.",
+  );
 }
 
 export function normalizeEmail(value: string): string {
@@ -47,80 +152,48 @@ export function validateEmailAddress(value: unknown): string {
   return normalizedEmail;
 }
 
-function isEmailSignupRecord(value: unknown): value is EmailSignupRecord {
-  if (!value || typeof value !== "object") {
-    return false;
+export async function readEmailSignups(
+  store: EmailSignupsStore = getEmailSignupsStore(),
+): Promise<EmailSignupRecord[]> {
+  try {
+    return await store.listSignups();
+  } catch (error) {
+    throw toStorageError(error);
   }
-
-  const record = value as Record<string, unknown>;
-
-  return (
-    typeof record.email === "string" &&
-    typeof record.submittedAt === "string" &&
-    !Number.isNaN(Date.parse(record.submittedAt))
-  );
 }
 
-export function readEmailSignups(
-  filePath = getEmailSignupsFilePath(),
-): EmailSignupRecord[] {
-  if (!fs.existsSync(filePath)) {
-    return [];
-  }
-
-  let parsed: unknown;
+export async function saveEmailSignup(
+  email: unknown,
+  store: EmailSignupsStore = getEmailSignupsStore(),
+): Promise<EmailSignupResult> {
+  const normalizedEmail = validateEmailAddress(email);
 
   try {
-    parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
-  } catch {
-    throw new EmailSignupStorageError(
-      `Email signup storage at "${filePath}" is not valid JSON.`,
-    );
+    const insertedSignup = await store.insertSignup({
+      email: normalizedEmail,
+      submittedAt: new Date().toISOString(),
+    });
+
+    if (insertedSignup) {
+      return {
+        record: insertedSignup,
+        status: "created",
+      };
+    }
+
+    const existingSignup = await store.findSignupByEmail(normalizedEmail);
+
+    if (existingSignup) {
+      return {
+        record: existingSignup,
+        status: "duplicate",
+      };
+    }
+  } catch (error) {
+    throw toStorageError(error);
   }
 
-  if (!Array.isArray(parsed) || !parsed.every(isEmailSignupRecord)) {
-    throw new EmailSignupStorageError(
-      `Email signup storage at "${filePath}" has an invalid shape.`,
-    );
-  }
-
-  return parsed;
-}
-
-export function saveEmailSignup(
-  email: unknown,
-  filePath = getEmailSignupsFilePath(),
-): EmailSignupResult {
-  const normalizedEmail = validateEmailAddress(email);
-  const existingSignups = readEmailSignups(filePath);
-  const existingSignup = existingSignups.find(
-    (signup) => signup.email === normalizedEmail,
+  throw new EmailSignupStorageError(
+    "Email signup storage is unavailable right now.",
   );
-
-  if (existingSignup) {
-    return {
-      record: existingSignup,
-      status: "duplicate",
-    };
-  }
-
-  const record = {
-    email: normalizedEmail,
-    submittedAt: new Date().toISOString(),
-  } satisfies EmailSignupRecord;
-
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-
-  const temporaryFilePath = `${filePath}.tmp`;
-
-  fs.writeFileSync(
-    temporaryFilePath,
-    JSON.stringify([...existingSignups, record], null, 2) + "\n",
-  );
-  fs.renameSync(temporaryFilePath, filePath);
-
-  return {
-    record,
-    status: "created",
-  };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "gray-matter": "^4.0.3",
         "next": "^16.1.6",
+        "postgres": "^3.4.8",
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "react-markdown": "^10.1.0",
@@ -7707,6 +7708,19 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.8.tgz",
+      "integrity": "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "gray-matter": "^4.0.3",
     "next": "^16.1.6",
+    "postgres": "^3.4.8",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-markdown": "^10.1.0",


### PR DESCRIPTION
## Summary
- replace file-backed email signup persistence with database-backed storage using `DATABASE_URL`
- return friendlier created and duplicate responses from the signup API route
- validate the route locally, in tests, and against a live built app with a real database write and duplicate check

Closes #33