### PR TITLE
feat: add accessible loading/success/error states to email signup

### DIFF
--- a/components/site/EmailSignupForm.test.tsx
+++ b/components/site/EmailSignupForm.test.tsx
@@ -12,5 +12,10 @@ describe("EmailSignupForm", () => {
     expect(markup).toContain("name=\"email\"");
     expect(markup).toContain("type=\"email\"");
     expect(markup).toContain("Join updates");
+    expect(markup).toContain("id=\"email-signup-status\"");
+    expect(markup).toContain("aria-live=\"polite\"");
+    expect(markup).toContain(
+      "Expect occasional notes focused on shipped work, not marketing noise.",
+    );
   });
 });

--- a/components/site/EmailSignupForm.tsx
+++ b/components/site/EmailSignupForm.tsx
@@ -1,62 +1,58 @@
 "use client";
 
 import type { FormEvent } from "react";
-import { useState, useTransition } from "react";
+import { useState } from "react";
 
-type SubmissionState = {
-  message: string;
-  tone: "error" | "idle" | "success";
-};
+import {
+  createErrorEmailSignupSubmissionState,
+  createIdleEmailSignupSubmissionState,
+  createLoadingEmailSignupSubmissionState,
+  createSuccessEmailSignupSubmissionState,
+  type EmailSignupSubmissionState,
+} from "./email-signup-submission-state";
 
 export default function EmailSignupForm() {
   const [email, setEmail] = useState("");
-  const [submissionState, setSubmissionState] = useState<SubmissionState>({
-    message: "",
-    tone: "idle",
-  });
-  const [isPending, startTransition] = useTransition();
+  const [submissionState, setSubmissionState] = useState<EmailSignupSubmissionState>(
+    createIdleEmailSignupSubmissionState(),
+  );
+  const isLoading = submissionState.phase === "loading";
+  const isError = submissionState.phase === "error";
+  const isSuccess = submissionState.phase === "success";
 
-  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
+    if (isLoading || isSuccess) {
+      return;
+    }
+
     const submittedEmail = email;
+    setSubmissionState(createLoadingEmailSignupSubmissionState());
 
-    startTransition(async () => {
-      try {
-        const response = await fetch("/api/email-signups", {
-          body: JSON.stringify({ email: submittedEmail }),
-          headers: {
-            "content-type": "application/json",
-          },
-          method: "POST",
-        });
-        const payload = (await response.json()) as {
-          message?: string;
-          ok?: boolean;
-        };
+    try {
+      const response = await fetch("/api/email-signups", {
+        body: JSON.stringify({ email: submittedEmail }),
+        headers: {
+          "content-type": "application/json",
+        },
+        method: "POST",
+      });
+      const payload = (await response.json()) as {
+        message?: string;
+        ok?: boolean;
+      };
 
-        if (!response.ok || !payload.ok) {
-          setSubmissionState({
-            message:
-              payload.message ?? "Unable to store your email right now.",
-            tone: "error",
-          });
+      if (!response.ok || !payload.ok) {
+        setSubmissionState(createErrorEmailSignupSubmissionState(payload.message));
 
-          return;
-        }
-
-        setEmail("");
-        setSubmissionState({
-          message: payload.message ?? "You are on the list for Evolvo updates.",
-          tone: "success",
-        });
-      } catch {
-        setSubmissionState({
-          message: "Unable to store your email right now.",
-          tone: "error",
-        });
+        return;
       }
-    });
+
+      setSubmissionState(createSuccessEmailSignupSubmissionState(payload.message));
+    } catch {
+      setSubmissionState(createErrorEmailSignupSubmissionState());
+    }
   }
 
   return (
@@ -68,40 +64,62 @@ export default function EmailSignupForm() {
         Get concise updates when accepted changes land, new writing is
         published, or the next stage of work opens.
       </p>
-      <form className="mt-5 space-y-3" onSubmit={handleSubmit}>
-        <label
-          htmlFor="email-signup"
-          className="font-mono text-[0.68rem] uppercase tracking-[0.24em] text-stone-400"
-        >
-          Email address
-        </label>
-        <input
-          id="email-signup"
-          name="email"
-          type="email"
-          autoComplete="email"
-          required
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-          placeholder="operator@example.com"
-          className="w-full rounded-2xl border border-stone-700 bg-stone-950 px-4 py-3 text-sm text-stone-100 outline-none transition-colors placeholder:text-stone-500 focus:border-amber-400"
-        />
-        <button
-          type="submit"
-          disabled={isPending}
-          className="inline-flex items-center justify-center rounded-full border border-amber-400 bg-amber-400 px-5 py-3 font-mono text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-stone-950 transition-colors hover:bg-amber-300 disabled:cursor-not-allowed disabled:border-stone-700 disabled:bg-stone-800 disabled:text-stone-400"
-        >
-          {isPending ? "Submitting" : "Join updates"}
-        </button>
-      </form>
+      {isSuccess ? (
+        <div className="mt-5 rounded-2xl border border-amber-500/40 bg-stone-950 p-4">
+          <p className="font-mono text-[0.68rem] uppercase tracking-[0.24em] text-amber-300">
+            Signup confirmed
+          </p>
+          <p className="mt-2 text-sm leading-7 text-stone-200">
+            {submissionState.message}
+          </p>
+        </div>
+      ) : (
+        <form className="mt-5 space-y-3" onSubmit={handleSubmit} aria-busy={isLoading}>
+          <label
+            htmlFor="email-signup"
+            className="font-mono text-[0.68rem] uppercase tracking-[0.24em] text-stone-400"
+          >
+            Email address
+          </label>
+          <input
+            id="email-signup"
+            name="email"
+            type="email"
+            autoComplete="email"
+            required
+            disabled={isLoading}
+            value={email}
+            onChange={(event) => {
+              setEmail(event.target.value);
+
+              if (isError) {
+                setSubmissionState(createIdleEmailSignupSubmissionState());
+              }
+            }}
+            aria-invalid={isError || undefined}
+            aria-describedby="email-signup-status"
+            placeholder="operator@example.com"
+            className="w-full rounded-2xl border border-stone-700 bg-stone-950 px-4 py-3 text-sm text-stone-100 outline-none transition-colors placeholder:text-stone-500 focus:border-amber-400 disabled:cursor-not-allowed disabled:opacity-70"
+          />
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="inline-flex items-center justify-center rounded-full border border-amber-400 bg-amber-400 px-5 py-3 font-mono text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-stone-950 transition-colors hover:bg-amber-300 disabled:cursor-not-allowed disabled:border-stone-700 disabled:bg-stone-800 disabled:text-stone-400"
+          >
+            {isLoading ? "Submitting..." : "Join updates"}
+          </button>
+        </form>
+      )}
       <p
-        aria-live="polite"
+        id="email-signup-status"
+        role={isError ? "alert" : "status"}
+        aria-live={isError ? "assertive" : "polite"}
+        aria-atomic="true"
         className={`mt-3 text-sm leading-7 ${
-          submissionState.tone === "error" ? "text-amber-300" : "text-stone-300"
+          isError ? "text-amber-300" : "text-stone-300"
         }`}
       >
-        {submissionState.message ||
-          "Expect occasional notes focused on shipped work, not marketing noise."}
+        {submissionState.message}
       </p>
     </div>
   );

--- a/components/site/email-signup-submission-state.test.ts
+++ b/components/site/email-signup-submission-state.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createErrorEmailSignupSubmissionState,
+  createIdleEmailSignupSubmissionState,
+  createLoadingEmailSignupSubmissionState,
+  createSuccessEmailSignupSubmissionState,
+  DEFAULT_EMAIL_SIGNUP_STATUS_MESSAGE,
+} from "./email-signup-submission-state";
+
+describe("email signup submission state", () => {
+  it("creates the idle state with default helper text", () => {
+    expect(createIdleEmailSignupSubmissionState()).toEqual({
+      message: DEFAULT_EMAIL_SIGNUP_STATUS_MESSAGE,
+      phase: "idle",
+    });
+  });
+
+  it("creates a loading state with a progress message", () => {
+    expect(createLoadingEmailSignupSubmissionState()).toEqual({
+      message: "Submitting your email now.",
+      phase: "loading",
+    });
+  });
+
+  it("creates an error state with default fallback text", () => {
+    expect(createErrorEmailSignupSubmissionState()).toEqual({
+      message: "Unable to store your email right now.",
+      phase: "error",
+    });
+  });
+
+  it("creates an error state with custom text when provided", () => {
+    expect(createErrorEmailSignupSubmissionState("Enter a valid email address.")).toEqual({
+      message: "Enter a valid email address.",
+      phase: "error",
+    });
+  });
+
+  it("creates a success state with default fallback text", () => {
+    expect(createSuccessEmailSignupSubmissionState()).toEqual({
+      message: "Thanks, you are on the list for Evolvo updates.",
+      phase: "success",
+    });
+  });
+
+  it("creates a success state with custom text when provided", () => {
+    expect(
+      createSuccessEmailSignupSubmissionState("You are already on the list for Evolvo updates."),
+    ).toEqual({
+      message: "You are already on the list for Evolvo updates.",
+      phase: "success",
+    });
+  });
+});

--- a/components/site/email-signup-submission-state.ts
+++ b/components/site/email-signup-submission-state.ts
@@ -1,0 +1,46 @@
+export type EmailSignupSubmissionPhase = "error" | "idle" | "loading" | "success";
+
+export type EmailSignupSubmissionState = {
+  message: string;
+  phase: EmailSignupSubmissionPhase;
+};
+
+export const DEFAULT_EMAIL_SIGNUP_STATUS_MESSAGE =
+  "Expect occasional notes focused on shipped work, not marketing noise.";
+
+const DEFAULT_EMAIL_SIGNUP_ERROR_MESSAGE = "Unable to store your email right now.";
+const DEFAULT_EMAIL_SIGNUP_SUCCESS_MESSAGE =
+  "Thanks, you are on the list for Evolvo updates.";
+const EMAIL_SIGNUP_LOADING_MESSAGE = "Submitting your email now.";
+
+export function createIdleEmailSignupSubmissionState(): EmailSignupSubmissionState {
+  return {
+    message: DEFAULT_EMAIL_SIGNUP_STATUS_MESSAGE,
+    phase: "idle",
+  };
+}
+
+export function createLoadingEmailSignupSubmissionState(): EmailSignupSubmissionState {
+  return {
+    message: EMAIL_SIGNUP_LOADING_MESSAGE,
+    phase: "loading",
+  };
+}
+
+export function createErrorEmailSignupSubmissionState(
+  message?: string,
+): EmailSignupSubmissionState {
+  return {
+    message: message ?? DEFAULT_EMAIL_SIGNUP_ERROR_MESSAGE,
+    phase: "error",
+  };
+}
+
+export function createSuccessEmailSignupSubmissionState(
+  message?: string,
+): EmailSignupSubmissionState {
+  return {
+    message: message ?? DEFAULT_EMAIL_SIGNUP_SUCCESS_MESSAGE,
+    phase: "success",
+  };
+}


### PR DESCRIPTION
## Summary
- add explicit idle/loading/success/error submission states for the email signup form
- disable controls while submission is in flight and guard against duplicate submits
- replace the form with a clear success confirmation block after successful signup
- preserve entered email on failures, expose error semantics via aria-invalid, and announce updates with aria-live
- extract submission state builders into a pure module with unit tests

## Validation
- npm run lint
- npm run build
- npm run test

Closes #39
